### PR TITLE
Adding support for NULL values

### DIFF
--- a/src/EPDOStatement.php
+++ b/src/EPDOStatement.php
@@ -169,10 +169,10 @@ class EPDOStatement extends PDOStatement
      */
     private function prepareValue($value)
     {
-		if ($value['value'] === NULL)
-		{
-			return 'NULL';
-		}
+        if ($value['value'] === NULL)
+        {
+            return 'NULL';
+        }
         
         if (!$this->_pdo) {
             return "'" . addslashes($value['value']) . "'";

--- a/src/EPDOStatement.php
+++ b/src/EPDOStatement.php
@@ -169,6 +169,11 @@ class EPDOStatement extends PDOStatement
      */
     private function prepareValue($value)
     {
+		if ($value['value'] === NULL)
+		{
+			return 'NULL';
+		}
+        
         if (!$this->_pdo) {
             return "'" . addslashes($value['value']) . "'";
         }


### PR DESCRIPTION
Both mysqli and PDO will bind NULL values as SQL NULLs. 